### PR TITLE
Add message splitting feature and improve configuration

### DIFF
--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -16,31 +16,30 @@ matrix:
 
   # End-to-end encryption settings (optional)
   # Only enable if you understand the implications and have proper key management
-  e2ee:
-    enabled: false
-    # Optional: override store path (default: ~/.config/matrix-biblebot/e2ee-store)
-    # Ensure this directory is private (0700) to protect keys.
-    store_path: null
-
-# Bot behavior configuration
-bot:
-  # Default Bible translation to use when none is specified
-  default_translation: kjv # Options: "kjv", "esv" (ESV requires api_keys.esv)
-
-  # Enable or disable caching of Bible passages
-  cache_enabled: true
-
-  # Maximum length for bot messages (characters)
-  # Messages longer than this will be truncated with "..."
-  max_message_length: 2000
-
-  # Split long messages into multiple messages of specified length
-  # Set to 0 or null to disable message splitting (default behavior)
-  # When enabled, messages longer than this will be split into multiple messages
-  # split_message_length: 0 # Disabled by default
+  # e2ee:
+  #   enabled: false
+  #   # Optional: override store path (default: ~/.config/matrix-biblebot/e2ee-store)
+  #   # Ensure this directory is private (0700) to protect keys.
+  #   store_path: null
+# Bot behavior configuration (optional - defaults shown)
+# bot:
+#   # Default Bible translation to use when none is specified
+#   default_translation: kjv # Options: "kjv", "esv" (ESV requires api_keys.esv)
+#
+#   # Enable or disable caching of Bible passages
+#   cache_enabled: true
+#
+#   # Maximum length for bot messages (characters)
+#   # Messages longer than this will be truncated with "..."
+#   max_message_length: 2000
+#
+#   # Split long messages into multiple messages of specified length
+#   # Set to 0 or null to disable message splitting (default behavior)
+#   # When enabled, messages longer than this will be split into multiple messages
+#   split_message_length: 0 # Disabled by default
 
 # API Keys for Bible translations (optional)
 # These can also be set via environment variables
-api_keys:
-  # ESV API key from https://api.esv.org/
-  esv: null
+# api_keys:
+#   # ESV API key from https://api.esv.org/
+#   esv: null

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -17,6 +17,8 @@ matrix:
   # End-to-end encryption settings (optional)
   # Only enable if you understand the implications and have proper key management
   # e2ee:
+  #   # Requires: pip install matrix-nio[e2e]
+  #   # Manual access tokens do NOT support E2EE
   #   enabled: false
   #   # Optional: override store path (default: ~/.config/matrix-biblebot/e2ee-store)
   #   # Ensure this directory is private (0700) to protect keys.
@@ -41,5 +43,6 @@ matrix:
 # API Keys for Bible translations (optional)
 # These can also be set via environment variables
 # api_keys:
+#   # Or set via env var: ESV_API_KEY
 #   # ESV API key from https://api.esv.org/
 #   esv: null

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -9,7 +9,8 @@ matrix:
 
   # List of Matrix room IDs or aliases where the bot should respond
   # Get room IDs from Element: Room Settings > Advanced > Internal room ID
-  # Both internal IDs ("!...") and room aliases ("#...") are supported
+  # Both internal IDs ("!...") and room aliases ("#...") are supported.
+  # Aliases are resolved to room IDs on startup; the bot stores canonical IDs thereafter.
   room_ids:
     - "!your_room_id:your_homeserver_domain"
     - "!your_other_room_id:your_homeserver_domain"
@@ -48,7 +49,7 @@ matrix:
 #   split_message_length: 0 # Disabled by default
 
 # API Keys for Bible translations (optional)
-# These can also be set via environment variables.
+# These can also be set via environment variables (e.g., ESV_API_KEY).
 # Note: Using a .env file is deprecated; prefer config.yaml or real env vars.
 # api_keys:
 #   # Or set via env var: ESV_API_KEY

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -37,11 +37,14 @@ matrix:
 #
 #   # Split long messages into multiple messages of specified length
 #   # Set to 0 or null to disable message splitting (default behavior)
-#   # When enabled, messages longer than this will be split into multiple messages
+#   # When enabled, messages longer than this will be split into multiple messages.
+#   # Note: This value is capped to max_message_length. The final chunk reserves
+#   # space for the reference and suffix, so its text portion may be shorter.
 #   split_message_length: 0 # Disabled by default
 
 # API Keys for Bible translations (optional)
-# These can also be set via environment variables
+# These can also be set via environment variables.
+# Note: Using a .env file is deprecated; prefer config.yaml or real env vars.
 # api_keys:
 #   # Or set via env var: ESV_API_KEY
 #   # ESV API key from https://api.esv.org/

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -34,6 +34,11 @@ bot:
   # Messages longer than this will be truncated with "..."
   max_message_length: 2000
 
+  # Split long messages into multiple messages of specified length
+  # Set to 0 or null to disable message splitting (default behavior)
+  # When enabled, messages longer than this will be split into multiple messages
+  split_message_length: 0 # Disabled by default
+
 # API Keys for Bible translations (optional)
 # These can also be set via environment variables
 api_keys:

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -13,12 +13,14 @@ matrix:
   room_ids:
     - "!your_room_id:your_homeserver_domain"
     - "!your_other_room_id:your_homeserver_domain"
+    # - "#your_room_alias:your_homeserver_domain"  # aliases are also supported
 
   # End-to-end encryption settings (optional)
   # Only enable if you understand the implications and have proper key management
   # e2ee:
   #   # Requires: pip install matrix-nio[e2e]
   #   # Manual access tokens do NOT support E2EE
+  #   # Requires: `biblebot auth login` (credentials.json); legacy MATRIX_ACCESS_TOKEN cannot be used with E2EE
   #   enabled: false
   #   # Optional: override store path (default: ~/.config/matrix-biblebot/e2ee-store)
   #   # Ensure this directory is private (0700) to protect keys.
@@ -30,6 +32,9 @@ matrix:
 #
 #   # Enable or disable caching of Bible passages
 #   cache_enabled: true
+#
+#   # Preserve poetry formatting (newlines kept; HTML uses <br />)
+#   preserve_poetry_formatting: false
 #
 #   # Maximum length for bot messages (characters)
 #   # Messages longer than this will be truncated with "..."

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -37,7 +37,7 @@ bot:
   # Split long messages into multiple messages of specified length
   # Set to 0 or null to disable message splitting (default behavior)
   # When enabled, messages longer than this will be split into multiple messages
-  split_message_length: 0 # Disabled by default
+  # split_message_length: 0 # Disabled by default
 
 # API Keys for Bible translations (optional)
 # These can also be set via environment variables

--- a/sample_config.yaml
+++ b/sample_config.yaml
@@ -7,9 +7,9 @@ matrix:
   # homeserver: https://matrix.example.org
   # user: "@bot:example.org"
 
-  # List of Matrix room IDs where the bot should respond
+  # List of Matrix room IDs or aliases where the bot should respond
   # Get room IDs from Element: Room Settings > Advanced > Internal room ID
-  # Use internal IDs beginning with "!" (not room aliases beginning with "#")
+  # Both internal IDs ("!...") and room aliases ("#...") are supported
   room_ids:
     - "!your_room_id:your_homeserver_domain"
     - "!your_other_room_id:your_homeserver_domain"

--- a/src/biblebot/bot.py
+++ b/src/biblebot/bot.py
@@ -75,6 +75,9 @@ from .constants import (
 # Configure logging
 logger = logging.getLogger(LOGGER_NAME)
 
+# Constants
+FALLBACK_MESSAGE_TOO_LONG = "[Message too long]"
+
 
 # Custom exceptions for Bible text retrieval
 class PassageNotFound(Exception):
@@ -972,8 +975,8 @@ class BibleBot:
             return None
 
         # Calculate budget for reference (reserve space for " - ", MESSAGE_SUFFIX, and fallback text)
-        # Reserve space for "[Message too long]" (18 chars) as worst case
-        fallback_text_len = len("[Message too long]")
+        # Reserve space for fallback text as worst case
+        fallback_text_len = len(FALLBACK_MESSAGE_TOO_LONG)
         budget = (
             self.max_message_length - len(MESSAGE_SUFFIX) - 3 - fallback_text_len
         )  # " - " and fallback text
@@ -1149,10 +1152,9 @@ class BibleBot:
                 )
 
                 message_text = text
-                test_body = f"{text}{plain_suffix}"
 
                 # Apply message length truncation if needed
-                if len(test_body) > self.max_message_length:
+                if len(f"{text}{plain_suffix}") > self.max_message_length:
                     suffix_len = len(plain_suffix) + 3  # for "..."
 
                     # Determine truncated text
@@ -1163,7 +1165,7 @@ class BibleBot:
                             f"Truncated message from {len(text)} to {len(message_text)} characters"
                         )
                     else:
-                        message_text = "[Message too long]"
+                        message_text = FALLBACK_MESSAGE_TOO_LONG
 
                 # Send the single message (truncated or not)
                 await self._send_message_parts(

--- a/src/biblebot/log_utils.py
+++ b/src/biblebot/log_utils.py
@@ -102,9 +102,9 @@ def configure_component_debug_logging():
 def get_log_dir():
     """
     Return the default directory for application logs.
-    
+
     This is the application's config directory with "logs" appended (i.e., get_config_dir() / "logs").
-    
+
     Returns:
         pathlib.Path: Path to the logs directory (may not exist).
     """
@@ -241,16 +241,16 @@ def get_logger(name):
 def configure_logging(config_dict=None):
     """
     Set the module-wide logging configuration and apply per-component debug settings.
-    
+
     This stores the provided configuration dict in the module-level `config` variable (or clears it when None)
     and then applies component-specific debug levels by calling `configure_component_debug_logging()`.
-    
+
     Parameters:
         config_dict (dict | None): Global configuration mapping for logging. Expected keys are the same
             logging keys consumed elsewhere in this module (for example: `"level"`, `"color_enabled"`,
             `"log_to_file"`, `"filename"`, `"max_log_size"`, `"backup_count"`, and a `"debug"` mapping
             for per-component overrides). If None, the global configuration is cleared.
-    
+
     Returns:
         None
     """

--- a/src/biblebot/log_utils.py
+++ b/src/biblebot/log_utils.py
@@ -77,19 +77,16 @@ def configure_component_debug_logging():
 
         if component_config:
             # Component debug is enabled - check if it's a boolean or a log level
-            if isinstance(component_config, bool):
-                # Legacy boolean format - default to DEBUG
-                log_level = logging.DEBUG
-            elif isinstance(component_config, str):
-                # String log level format (e.g., "warning", "error", "debug")
+            # Default to DEBUG for all cases
+            log_level = logging.DEBUG
+
+            if isinstance(component_config, str):
+                # If it's a string, try to parse it as a log level
                 try:
                     log_level = getattr(logging, component_config.upper())
                 except AttributeError:
-                    # Invalid log level, fall back to DEBUG
-                    log_level = logging.DEBUG
-            else:
-                # Invalid config, fall back to DEBUG
-                log_level = logging.DEBUG
+                    # Invalid log level string, the default DEBUG will be used
+                    pass
 
             for logger_name in loggers:
                 logging.getLogger(logger_name).setLevel(log_level)

--- a/src/biblebot/tools/sample_config.yaml
+++ b/src/biblebot/tools/sample_config.yaml
@@ -22,6 +22,7 @@ bot:
   cache_enabled: true # Enable verse caching for better performance
   max_message_length: 4000 # Maximum message length before truncation
   preserve_poetry_formatting: false # Set to true to preserve line breaks in poetic texts (Psalms, etc.)
+  split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
 
 # API Keys (Optional)
 # You can also set these as environment variables: ESV_API_KEY

--- a/src/biblebot/tools/sample_config.yaml
+++ b/src/biblebot/tools/sample_config.yaml
@@ -22,7 +22,7 @@ bot:
   cache_enabled: true # Enable verse caching for better performance
   max_message_length: 4000 # Maximum message length before truncation
   preserve_poetry_formatting: false # Set to true to preserve line breaks in poetic texts (Psalms, etc.)
-  split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
+  # split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
 
 # API Keys (Optional)
 # You can also set these as environment variables: ESV_API_KEY

--- a/src/biblebot/tools/sample_config.yaml
+++ b/src/biblebot/tools/sample_config.yaml
@@ -8,23 +8,22 @@ matrix:
   room_ids:
     - "!your_room_id:your_homeserver_domain"
     - "!your_other_room_id:your_homeserver_domain"
-  # End-to-End Encryption (E2EE) Settings
+  # End-to-End Encryption (E2EE) Settings (optional)
   # Requires: pip install matrix-nio[e2e]
   # Note: E2EE requires proper authentication via 'biblebot auth login'
   # Manual access tokens do NOT support E2EE
-  e2ee:
-    enabled: false # Set to true to enable E2EE support
-    store_path: null # Optional: custom path for E2EE store (defaults to ~/.config/matrix-biblebot/e2ee-store)
-
-# Bot Behavior Settings
-bot:
-  default_translation: kjv # Default Bible translation (esv, kjv)
-  cache_enabled: true # Enable verse caching for better performance
-  max_message_length: 4000 # Maximum message length before truncation
-  preserve_poetry_formatting: false # Set to true to preserve line breaks in poetic texts (Psalms, etc.)
-  # split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
+  # e2ee:
+  #   enabled: false # Set to true to enable E2EE support
+  #   store_path: null # Optional: custom path for E2EE store (defaults to ~/.config/matrix-biblebot/e2ee-store)
+# Bot Behavior Settings (optional - defaults shown)
+# bot:
+#   default_translation: kjv # Default Bible translation (esv, kjv)
+#   cache_enabled: true # Enable verse caching for better performance
+#   max_message_length: 2000 # Maximum message length before truncation
+#   preserve_poetry_formatting: false # Set to true to preserve line breaks in poetic texts (Psalms, etc.)
+#   split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
 
 # API Keys (Optional)
 # You can also set these as environment variables: ESV_API_KEY
-api_keys:
-  esv: null # Optional: ESV API key for enhanced ESV support (get from https://api.esv.org/)
+# api_keys:
+#   esv: null # Optional: ESV API key for enhanced ESV support (get from https://api.esv.org/)

--- a/src/biblebot/tools/sample_config.yaml
+++ b/src/biblebot/tools/sample_config.yaml
@@ -22,6 +22,7 @@ matrix:
 #   max_message_length: 2000 # Maximum message length before truncation
 #   preserve_poetry_formatting: false # Set to true to preserve line breaks in poetic texts (Psalms, etc.)
 #   split_message_length: 0 # Split long messages into multiple messages of this length (0 = disabled)
+#   # Only the last split message includes the reference and any suffix (e.g., "- John 3:16 🕊️✝️")
 
 # API Keys (Optional)
 # You can also set these as environment variables: ESV_API_KEY

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -335,10 +335,10 @@ class TestMessageSplitting:
                 assert len(content["body"]) <= 50  # max_message_length
 
             # At least one message should contain some form of reference (trimmed)
-            any(
+            assert any(
                 "..." in call[0][2]["body"] or long_reference[:10] in call[0][2]["body"]
                 for call in message_calls
-            )
+            ), "Expected a trimmed or partial reference in at least one message"
             # Note: reference might be completely dropped if too long, so this is optional
             # The important thing is that no message exceeds the length limit
 

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -371,11 +371,15 @@ class TestMessageSplitting:
             )
 
         # message is second call (after reaction)
-        msg = [
-            c
-            for c in mock_client.room_send.call_args_list
-            if c[0][1] == "m.room.message"
-        ][0]
+        msg = next(
+            (
+                c
+                for c in mock_client.room_send.call_args_list
+                if c[0][1] == "m.room.message"
+            ),
+            None,
+        )
+        assert msg is not None, "No m.room.message call captured"
         body = msg[0][2]["body"]
         assert len(body) <= 20
         # Either a trimmed reference or suffix-only (implementation-dependent), but never overflow

--- a/tests/test_bot_config.py
+++ b/tests/test_bot_config.py
@@ -152,8 +152,8 @@ class TestMessageSplitting:
         assert len(chunks) > 1
         for chunk in chunks:
             assert len(chunk) <= 20
-        # Verify all text is preserved
-        assert " ".join(chunks) == long_text
+        # Verify all text is preserved (normalize whitespace for comparison)
+        assert " ".join(chunks).split() == long_text.split()
         # No leading/trailing spaces in any chunk
         assert all(c == c.strip() for c in chunks)
 


### PR DESCRIPTION
## Changes

### Message Splitting Feature
- Added `split_message_length` configuration option to split long Bible passages into multiple messages
- Messages are split at word boundaries when possible to avoid breaking words
- Only the last message in a split sequence includes the reference and suffix (e.g., "- John 3:16 🕊️✝️")
- Feature is disabled by default (value: 0) to maintain backward compatibility
- When disabled, existing truncation behavior is preserved

### Configuration Improvements
- Commented out all optional configuration settings in sample configs
- Only required settings (room_ids, version) remain uncommented
- All optional settings show their default values as comments
- Fixed incorrect max_message_length default from 4000 to 2000 in tools sample config
- Makes sample configs cleaner and less confusing for new users

### Testing
- Added comprehensive tests for message splitting functionality
- Added tests for configuration parsing and validation
- All existing tests continue to pass

### Infrastructure
- Added GitHub Actions workflows for testing and releases
- Added codecov configuration for coverage reporting
- Updated trunk configuration and dependencies
- Added comprehensive testing documentation

## Files Changed
- `src/biblebot/bot.py`: Added splitting logic and configuration handling
- `sample_config.yaml` and `src/biblebot/tools/sample_config.yaml`: Commented out optional features
- `tests/test_bot_config.py`: Added tests for new functionality
- Various CI/CD and documentation improvements


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Optional message splitting for long scripture responses (split_message_length) — final part includes the reference and suffix.
  - In-room, user-facing error messages when a required API key is missing.
  - Per-component debug logging control via configuration.

- Documentation
  - Sample config converted to commented, documentation-style templates; E2EE, bot, and API keys shown as optional.
  - Example max_message_length set to 2000 and split_message_length documented.

- Tests
  - Comprehensive tests for splitting, truncation, config loading, and related behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->